### PR TITLE
Added a config manager and relative path parsing of config file

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,12 @@
+from os.path import realpath, dirname
+import json
+
+cfg_file_path = realpath(dirname(__file__) + "/config/config.json")
+
+with open(cfg_file_path, "r+") as f:
+	config = json.load(f)
+
+# parse paths in config
+config["database"]["path"] = realpath(dirname(__file__) 
+				+ "/"
+				+ config["database"]["path"])

--- a/main.py
+++ b/main.py
@@ -10,11 +10,7 @@ from peewee import *
 from emoji import emojize
 from telegram.ext import Updater, InlineQueryHandler, CallbackQueryHandler
 from telegram.ext import MessageHandler, CommandHandler, Filters
-
-
-with open('config/config.json', "r+") as f:
-    f.seek(0)
-    config = json.load(f)
+from config import config
 
 db = SqliteDatabase(config["database"]["path"])
 updater = Updater(token=config["token"])

--- a/tables.py
+++ b/tables.py
@@ -1,9 +1,8 @@
 import json
 from peewee import *
 import datetime
-
-with open('config/config.json') as f:
-    config = json.load(f)
+import os
+from config import config
 
 db = SqliteDatabase(config["database"]["path"])
 

--- a/util.py
+++ b/util.py
@@ -1,11 +1,7 @@
 from mwt import MWT
 from functools import wraps
 import json
-
-
-with open('config/config.json') as f:
-    config = json.load(f)
-
+from config import config
 
 # Returns a list of admin IDs for a given chat. Results are cached for 15 min.
 @MWT(timeout=60*15)


### PR DESCRIPTION
I have the bot running automatically using systemd on Debian. The former implementation required a cd into the checkout directory. These changes make it so that the bot can be launched while in any directory and consolidates the config file parsing into one script rather than opening the file in multiple scripts.