### PR TITLE
fix adventure cards etc

### DIFF
--- a/on_common.py
+++ b/on_common.py
@@ -65,7 +65,7 @@ def cards(update: Update, context: CallbackContext):
                               + legal_text, use_aliases=True)
 
         try:
-            card.card_faces()
+            card.card_faces()[0]['image_uris']
             is_flipcard = True
         except KeyError:
             is_flipcard = False


### PR DESCRIPTION
Hey!
I noticed your current version was not working with adventure cards and split cards (e.g. Find // Finality).

I patched it, with the assumption that only flip cards have the key : ['image_uris'].

